### PR TITLE
Adding feature to automatically open the new note when it is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ python __main__.py list
 ```
 
 ToDo:
+- [x] Add feature to automatically open new notes in NeoVim
+- [ ] Clean up the codebase. Add some more comments.
 - [ ] Compile this so it can be installed and run as a CLI tool
 - [ ] Add the ability to specify and use templates when creating new notes
 

--- a/zet_cli/model.py
+++ b/zet_cli/model.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import os
 from pathlib import Path
+from subprocess import call
 
 
 @dataclass
@@ -10,6 +11,7 @@ class Configuration():
     file_path:Path = Path(os.getenv("ZET_PATH", Path(Path.home(), 'zet')))
     file_name = os.getenv("ZET_FILE_NAME", "README.md")
     folder_name_format = os.getenv("ZET_FOLDER_NAME_FORMAT", "%Y%m%d%H%M%S%f")
+    editor = os.environ.get('EDITOR', 'nvim')
     template = "# Q: \n\n" \
             "Related:\n-\n\n" \
             "Tags:\n-"
@@ -43,6 +45,8 @@ def create_new_zettelkasten():
     new_file = Path(folder_path, configuration.file_name)
     with open(new_file, 'w') as file:
         file.write(configuration.template)
+        file.flush()
+        call([configuration.editor, file.name])
     
     print(new_file)
 


### PR DESCRIPTION
Used the `subprocess` module to open a subprocess and run your configured `$EDITOR`. If `$EDITOR` is not set, it falls back to `nvim`.